### PR TITLE
libsslsupport: remove redundant *str check

### DIFF
--- a/libsslsupport/wrapper.c
+++ b/libsslsupport/wrapper.c
@@ -24,7 +24,7 @@ int atoi(const char *str)
 	char c;
 
 	/* skip preceding white space */
-	while (*str && *str == ' ')
+	while (*str == ' ')
 		str ++;
 
 	/* convert digits */


### PR DESCRIPTION
The check to see if *str is non-zero while also checking to
see if it is a space char is redundant, one just needs to
check to see if *str is a space.  Remove the redundant check.

Signed-off-by: Colin Ian King <colin.king@canonical.com>